### PR TITLE
bump action to node 20

### DIFF
--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./ # Uses an action in the root directory
         with:
           cache_key: ${{ inputs.cache_key }}

--- a/.github/workflows/test-buildjet-cache.yml
+++ b/.github/workflows/test-buildjet-cache.yml
@@ -1,5 +1,7 @@
 name: Create staging BuildJet Cache
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   test-buildjet-cache:
@@ -7,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create BuildJet Cache
-        uses: buildjet/cache@v3
+        uses: buildjet/cache@v4
         with:
           path: |
             ~/.npm

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'Cache Key to Delete'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
node 16 is deprecated in GitHub Actions.
bump to node 20.